### PR TITLE
Implement numeric-only directive

### DIFF
--- a/frontend/plataforma-capacitacion/src/app/shared/directives/solo-numeros.directive.ts
+++ b/frontend/plataforma-capacitacion/src/app/shared/directives/solo-numeros.directive.ts
@@ -1,11 +1,38 @@
-import { Directive } from '@angular/core';
+import { Directive, HostListener } from '@angular/core';
 
 @Directive({
   selector: '[appSoloNumeros]',
   standalone: false
 })
 export class SoloNumerosDirective {
+  private readonly regex = /^[0-9]*$/;
+  private readonly specialKeys = new Set([
+    'Backspace',
+    'Tab',
+    'End',
+    'Home',
+    'ArrowLeft',
+    'ArrowRight',
+    'Delete'
+  ]);
 
-  constructor() { }
+  @HostListener('keydown', ['$event'])
+  onKeyDown(event: KeyboardEvent): void {
+    if (this.specialKeys.has(event.key)) {
+      return;
+    }
+    const current: string = (event.target as HTMLInputElement).value;
+    const next: string = current.concat(event.key);
+    if (!this.regex.test(next)) {
+      event.preventDefault();
+    }
+  }
 
+  @HostListener('paste', ['$event'])
+  onPaste(event: ClipboardEvent): void {
+    const pastedInput: string = event.clipboardData?.getData('text') ?? '';
+    if (!this.regex.test(pastedInput)) {
+      event.preventDefault();
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- prevent non-numeric input on fields using `SoloNumerosDirective`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684830b2d5b8832892ba7a70beaf657d