### PR TITLE
Improve login page styles

### DIFF
--- a/frontend/plataforma-capacitacion/src/app/features/auth/pages/login/login.component.css
+++ b/frontend/plataforma-capacitacion/src/app/features/auth/pages/login/login.component.css
@@ -1,0 +1,49 @@
+:host {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  width: 100%;
+  background-color: #fff;
+}
+
+.login-container {
+  background-color: #f3f3f3;
+  padding: 2rem;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 400px;
+}
+
+.login-container h2 {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.login-container div {
+  margin-bottom: 1rem;
+}
+
+.login-container input {
+  width: 100%;
+  padding: 0.5rem;
+  border: 2px solid #000;
+  background-color: #f3f3f3;
+  border-radius: 4px;
+  box-sizing: border-box;
+}
+
+button {
+  display: block;
+  margin: 0 auto;
+  background-color: var(--color-brand);
+  color: #fff;
+  border: none;
+  padding: 0.6rem 1.2rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+button:disabled {
+  background-color: #ccc;
+}


### PR DESCRIPTION
## Summary
- restyle login page so the form is centered
- set page background to white
- give inputs black borders and grey background

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*
- `npm test --prefix frontend/plataforma-capacitacion` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486d88cacc8328ba7d1f9dfc34089f