### PR TITLE
Update login styling with palette colors

### DIFF
--- a/frontend/plataforma-capacitacion/src/app/features/auth/pages/login/login.component.css
+++ b/frontend/plataforma-capacitacion/src/app/features/auth/pages/login/login.component.css
@@ -4,13 +4,16 @@
   align-items: center;
   height: 100vh;
   width: 100%;
-  background-color: #fff;
+  background-image: url('/img/490927947_1196119232521308_3084333383543494440_n.jpg');
+  background-size: cover;
+  background-position: center;
 }
 
 .login-container {
-  background-color: #f3f3f3;
+  background-color: var(--color-bg-gray);
   padding: 2rem;
   border-radius: 8px;
+  border: 2px solid var(--color-black);
   width: 100%;
   max-width: 400px;
 }
@@ -27,8 +30,8 @@
 .login-container input {
   width: 100%;
   padding: 0.5rem;
-  border: 2px solid #000;
-  background-color: #f3f3f3;
+  border: 2px solid var(--color-black);
+  background-color: var(--color-white);
   border-radius: 4px;
   box-sizing: border-box;
 }
@@ -36,9 +39,9 @@
 button {
   display: block;
   margin: 0 auto;
-  background-color: #000;
-  color: #fff;
-  border: 2px solid #000;
+  background-color: var(--color-black);
+  color: var(--color-white);
+  border: 2px solid var(--color-black);
   padding: 0.6rem 1.2rem;
   border-radius: 4px;
   cursor: pointer;
@@ -46,7 +49,8 @@ button {
 }
 
 button:hover {
-  background-color: red;
+  background-color: var(--color-brand);
+  border-color: var(--color-brand);
 }
 
 button:disabled {

--- a/frontend/plataforma-capacitacion/src/app/shared/styles/colors.css
+++ b/frontend/plataforma-capacitacion/src/app/shared/styles/colors.css
@@ -6,4 +6,6 @@
   --color-bg-gray: #bebebe;
   --color-border-gray: #e0e0e0;
   --color-light-gray: #f3f3f3;
+  --color-black: #000000;
+  --color-white: #ffffff;
 }


### PR DESCRIPTION
## Summary
- add black and white variables to color palette
- apply new palette to login styles and use background image

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497cdeea1c8328b9fe7b7afe09c833