### PR TITLE
Update dashboard and card styles

### DIFF
--- a/frontend/plataforma-capacitacion/src/app/features/dashboard/pages/panel-dashboard/panel-dashboard.component.css
+++ b/frontend/plataforma-capacitacion/src/app/features/dashboard/pages/panel-dashboard/panel-dashboard.component.css
@@ -1,6 +1,23 @@
+:host {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  min-height: 100vh;
+  width: 100%;
+  background-image:
+    linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)),
+    url(/img/490927947_1196119232521308_3084333383543494440_n.jpg);
+  background-size: cover;
+  background-position: center;
+  padding-top: 2rem;
+}
+
 .dashboard {
-  background-color: #fff;
-  padding: 3rem 2rem;
+  background-color: var(--color-bg-gray);
+  padding: 2rem;
+  border-radius: 8px;
+  border: 2px solid var(--color-black);
+  width: 100%;
   color: #111;
 }
 

--- a/frontend/plataforma-capacitacion/src/app/shared/components/card/card.component.css
+++ b/frontend/plataforma-capacitacion/src/app/shared/components/card/card.component.css
@@ -1,22 +1,27 @@
 
+
 .card {
-  background: #fff;
-  border: 1px solid var(--color-border-gray);
+  background: var(--color-black);
+  color: var(--color-white);
+  border: 2px solid var(--color-black);
   border-radius: 8px;
   padding: 1rem;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   cursor: pointer;
-  transition: box-shadow 0.2s, transform 0.2s;
+  transition: box-shadow 0.2s, transform 0.2s, background-color 0.2s;
 }
   
 .card:hover {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
   transform: translateY(-4px);
+  background: var(--color-brand);
+  border-color: var(--color-brand);
+  color: var(--color-white);
 }
   
 .card__title {
   margin: 0 0 0.5rem;
   font-weight: 600;
-  color: var(--color-brand);
+  color: var(--color-white);
   text-align: center;
 }


### PR DESCRIPTION
## Summary
- restyle shared card component with black background and white text that turns red on hover
- give dashboard the same background image and container style as login

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684997589b188328aabca5b487fb05ef