### PR TITLE
Fix examenes components

### DIFF
--- a/frontend/plataforma-capacitacion/src/app/features/examenes/examenes-routing.module.ts
+++ b/frontend/plataforma-capacitacion/src/app/features/examenes/examenes-routing.module.ts
@@ -1,14 +1,15 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { ListaExamenesComponent } from './pages/listado-examenes/listado-examenes.component';
-import { ResponderExamenComponent } from './responder/pages/responder-examen/responder-examen.component';
 
 const routes: Routes = [
   { path: '', component: ListaExamenesComponent },           // /examenes
   { path: ':id/preguntas', loadChildren: () =>
       import('../preguntas/preguntas.module').then(m => m.PreguntasModule)
   },
-  { path: 'responder/:id', component: ResponderExamenComponent }
+  { path: 'responder/:id', loadComponent: () =>
+      import('./responder/pages/responder-examen/responder-examen.component').then(m => m.ResponderExamenComponent)
+  }
 
 ];
 

--- a/frontend/plataforma-capacitacion/src/app/features/examenes/pages/crear-examen/crear-examen.component.ts
+++ b/frontend/plataforma-capacitacion/src/app/features/examenes/pages/crear-examen/crear-examen.component.ts
@@ -1,10 +1,12 @@
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-crear-examen',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './crear-examen.component.html',
-  styleUrl: './crear-examen.component.css'
+  styleUrls: ['./crear-examen.component.css']
 })
 export class CrearExamenComponent {
 

--- a/frontend/plataforma-capacitacion/src/app/features/examenes/pages/detalle-examen/detalle-examen.component.ts
+++ b/frontend/plataforma-capacitacion/src/app/features/examenes/pages/detalle-examen/detalle-examen.component.ts
@@ -1,10 +1,12 @@
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-detalle-examen',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './detalle-examen.component.html',
-  styleUrl: './detalle-examen.component.css'
+  styleUrls: ['./detalle-examen.component.css']
 })
 export class DetalleExamenComponent {
 

--- a/frontend/plataforma-capacitacion/src/app/features/examenes/responder/pages/responder-examen/responder-examen.component.ts
+++ b/frontend/plataforma-capacitacion/src/app/features/examenes/responder/pages/responder-examen/responder-examen.component.ts
@@ -1,10 +1,13 @@
 import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { PreguntasService } from '../../../preguntas/services/preguntas.service';
 
 
 @Component({
   selector: 'app-responder-examen',
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './responder-examen.component.html',
   styleUrls: ['./responder-examen.component.css']
 })


### PR DESCRIPTION
## Summary
- fix standalone configuration for examenes components
- lazy load ResponderExamenComponent in routing

## Testing
- `npm test` *(fails: No binary for Chrome)*
- `npx ng build` *(fails: fonts.googleapis.com blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684c586a54f48328b1f686c8d349f9e2