### PR TITLE
Fix examenes components module integration

### DIFF
--- a/frontend/plataforma-capacitacion/src/app/features/examenes/examenes-routing.module.ts
+++ b/frontend/plataforma-capacitacion/src/app/features/examenes/examenes-routing.module.ts
@@ -7,8 +7,8 @@ const routes: Routes = [
   { path: ':id/preguntas', loadChildren: () =>
       import('../preguntas/preguntas.module').then(m => m.PreguntasModule)
   },
-  { path: 'responder/:id', loadComponent: () =>
-      import('./responder/pages/responder-examen/responder-examen.component').then(m => m.ResponderExamenComponent)
+  { path: 'responder/:id', loadChildren: () =>
+      import('./responder/responder.module').then(m => m.ResponderModule)
   }
 
 ];

--- a/frontend/plataforma-capacitacion/src/app/features/examenes/pages/crear-examen/crear-examen.component.ts
+++ b/frontend/plataforma-capacitacion/src/app/features/examenes/pages/crear-examen/crear-examen.component.ts
@@ -1,10 +1,8 @@
 import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-crear-examen',
-  standalone: true,
-  imports: [CommonModule],
+  standalone: false,
   templateUrl: './crear-examen.component.html',
   styleUrls: ['./crear-examen.component.css']
 })

--- a/frontend/plataforma-capacitacion/src/app/features/examenes/pages/detalle-examen/detalle-examen.component.ts
+++ b/frontend/plataforma-capacitacion/src/app/features/examenes/pages/detalle-examen/detalle-examen.component.ts
@@ -1,10 +1,8 @@
 import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-detalle-examen',
-  standalone: true,
-  imports: [CommonModule],
+  standalone: false,
   templateUrl: './detalle-examen.component.html',
   styleUrls: ['./detalle-examen.component.css']
 })

--- a/frontend/plataforma-capacitacion/src/app/features/examenes/responder/pages/responder-examen/responder-examen.component.ts
+++ b/frontend/plataforma-capacitacion/src/app/features/examenes/responder/pages/responder-examen/responder-examen.component.ts
@@ -1,13 +1,11 @@
 import { Component, OnInit } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { PreguntasService } from '../../../preguntas/services/preguntas.service';
 
 
 @Component({
   selector: 'app-responder-examen',
-  standalone: true,
-  imports: [CommonModule],
+  standalone: false,
   templateUrl: './responder-examen.component.html',
   styleUrls: ['./responder-examen.component.css']
 })

--- a/frontend/plataforma-capacitacion/src/app/features/examenes/responder/responder-routing.module.ts
+++ b/frontend/plataforma-capacitacion/src/app/features/examenes/responder/responder-routing.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { ResponderExamenComponent } from './pages/responder-examen/responder-examen.component';
+
+const routes: Routes = [
+  { path: '', component: ResponderExamenComponent }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class ResponderRoutingModule {}

--- a/frontend/plataforma-capacitacion/src/app/features/examenes/responder/responder.module.ts
+++ b/frontend/plataforma-capacitacion/src/app/features/examenes/responder/responder.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ResponderRoutingModule } from './responder-routing.module';
+import { ResponderExamenComponent } from './pages/responder-examen/responder-examen.component';
+
+@NgModule({
+  declarations: [ResponderExamenComponent],
+  imports: [CommonModule, ResponderRoutingModule]
+})
+export class ResponderModule {}


### PR DESCRIPTION
## Summary
- align examenes components with module-based setup
- convert responder exam to be declared in a new module
- create responder routing/module
- adjust examenes routing

## Testing
- `npm run build` *(fails: Inlining of fonts failed)*

------
https://chatgpt.com/codex/tasks/task_e_684d6c1eebd08328911782dd1b31c8a5