### PR TITLE
Add working guides feature

### DIFF
--- a/frontend/plataforma-capacitacion/src/app/features/guias/guias-routing.module.ts
+++ b/frontend/plataforma-capacitacion/src/app/features/guias/guias-routing.module.ts
@@ -1,10 +1,15 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { ListadoGuiasComponent } from './pages/listado-guias/listado-guias.component';
+import { HistorialGuiasComponent } from './pages/historial-guias/historial-guias.component';
 
-const routes: Routes = [];
+const routes: Routes = [
+  { path: '', component: ListadoGuiasComponent },
+  { path: 'historial', component: HistorialGuiasComponent }
+];
 
 @NgModule({
   imports: [RouterModule.forChild(routes)],
   exports: [RouterModule]
 })
-export class GuiasRoutingModule { }
+export class GuiasRoutingModule {}

--- a/frontend/plataforma-capacitacion/src/app/features/guias/guias.module.ts
+++ b/frontend/plataforma-capacitacion/src/app/features/guias/guias.module.ts
@@ -2,13 +2,16 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { GuiasRoutingModule } from './guias-routing.module';
-
+import { ListadoGuiasComponent } from './pages/listado-guias/listado-guias.component';
+import { HistorialGuiasComponent } from './pages/historial-guias/historial-guias.component';
+import { SharedModule } from '../../shared/shared.module';
 
 @NgModule({
-  declarations: [],
+  declarations: [ListadoGuiasComponent, HistorialGuiasComponent],
   imports: [
     CommonModule,
+    SharedModule,
     GuiasRoutingModule
   ]
 })
-export class GuiasModule { }
+export class GuiasModule {}

--- a/frontend/plataforma-capacitacion/src/app/features/guias/pages/historial-guias/historial-guias.component.css
+++ b/frontend/plataforma-capacitacion/src/app/features/guias/pages/historial-guias/historial-guias.component.css
@@ -1,0 +1,22 @@
+.historial-guias {
+  margin: 2rem auto;
+  padding: 2rem;
+  max-width: 700px;
+  background-color: var(--color-bg-gray);
+  border: 1px solid var(--color-black);
+  border-radius: 8px;
+}
+
+.guia-vista-item {
+  list-style: none;
+  background-color: var(--color-light-gray);
+  border: 1px solid var(--color-border-gray);
+  border-radius: 6px;
+  margin: 0.75rem 0;
+  padding: 0.75rem 1rem;
+}
+
+.fecha {
+  font-size: 0.8rem;
+  color: #555;
+}

--- a/frontend/plataforma-capacitacion/src/app/features/guias/pages/historial-guias/historial-guias.component.html
+++ b/frontend/plataforma-capacitacion/src/app/features/guias/pages/historial-guias/historial-guias.component.html
@@ -1,1 +1,11 @@
-<p>historial-guias works!</p>
+<div class="historial-guias">
+  <h2>Historial de guías vistas</h2>
+  <div *ngIf="cargando">Cargando...</div>
+  <div *ngIf="!cargando && vistas.length === 0">Aún no has visto ninguna guía.</div>
+  <ul *ngIf="!cargando">
+    <li *ngFor="let v of vistas" class="guia-vista-item">
+      <strong>{{ v.titulo }}</strong>
+      <p class="fecha">{{ v.fecha | date:'short' }}</p>
+    </li>
+  </ul>
+</div>

--- a/frontend/plataforma-capacitacion/src/app/features/guias/pages/historial-guias/historial-guias.component.ts
+++ b/frontend/plataforma-capacitacion/src/app/features/guias/pages/historial-guias/historial-guias.component.ts
@@ -1,11 +1,27 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { GuiasService } from '../../services/guias.service';
 
 @Component({
   selector: 'app-historial-guias',
-  imports: [],
   templateUrl: './historial-guias.component.html',
-  styleUrl: './historial-guias.component.css'
+  styleUrl: './historial-guias.component.css',
+  standalone: false
 })
-export class HistorialGuiasComponent {
+export class HistorialGuiasComponent implements OnInit {
+  vistas: any[] = [];
+  cargando = true;
 
+  constructor(private guiasSvc: GuiasService) {}
+
+  ngOnInit(): void {
+    this.guiasSvc.historial().subscribe({
+      next: data => {
+        this.vistas = data;
+        this.cargando = false;
+      },
+      error: () => {
+        this.cargando = false;
+      }
+    });
+  }
 }

--- a/frontend/plataforma-capacitacion/src/app/features/guias/pages/listado-guias/listado-guias.component.css
+++ b/frontend/plataforma-capacitacion/src/app/features/guias/pages/listado-guias/listado-guias.component.css
@@ -1,0 +1,24 @@
+.lista-guias {
+  margin: 2rem auto;
+  padding: 2rem;
+  max-width: 700px;
+  background-color: var(--color-bg-gray);
+  border: 1px solid var(--color-black);
+  border-radius: 8px;
+}
+
+.guia-item {
+  list-style: none;
+  background-color: var(--color-light-gray);
+  border: 1px solid var(--color-border-gray);
+  border-radius: 6px;
+  margin: 0.75rem 0;
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s, box-shadow 0.2s;
+}
+
+.guia-item:hover {
+  background-color: var(--color-white);
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+}

--- a/frontend/plataforma-capacitacion/src/app/features/guias/pages/listado-guias/listado-guias.component.html
+++ b/frontend/plataforma-capacitacion/src/app/features/guias/pages/listado-guias/listado-guias.component.html
@@ -1,1 +1,11 @@
-<p>listado-guias works!</p>
+<div class="lista-guias">
+  <h2>Guías disponibles</h2>
+  <div *ngIf="cargando">Cargando...</div>
+  <div *ngIf="!cargando && guias.length === 0">No hay guías disponibles.</div>
+  <ul *ngIf="!cargando">
+    <li *ngFor="let g of guias" (click)="abrir(g)" class="guia-item">
+      <strong>{{ g.titulo }}</strong>
+      <p *ngIf="g.descripcion">{{ g.descripcion }}</p>
+    </li>
+  </ul>
+</div>

--- a/frontend/plataforma-capacitacion/src/app/features/guias/pages/listado-guias/listado-guias.component.ts
+++ b/frontend/plataforma-capacitacion/src/app/features/guias/pages/listado-guias/listado-guias.component.ts
@@ -1,11 +1,33 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { GuiasService } from '../../services/guias.service';
+import { Guia } from '../../../../core/models';
 
 @Component({
   selector: 'app-listado-guias',
-  imports: [],
   templateUrl: './listado-guias.component.html',
-  styleUrl: './listado-guias.component.css'
+  styleUrl: './listado-guias.component.css',
+  standalone: false
 })
-export class ListadoGuiasComponent {
+export class ListadoGuiasComponent implements OnInit {
+  guias: Guia[] = [];
+  cargando = true;
 
+  constructor(private guiasSvc: GuiasService) {}
+
+  ngOnInit(): void {
+    this.guiasSvc.listar().subscribe({
+      next: data => {
+        this.guias = data;
+        this.cargando = false;
+      },
+      error: () => {
+        this.cargando = false;
+      }
+    });
+  }
+
+  abrir(guia: Guia) {
+    this.guiasSvc.registrarVista(guia.id).subscribe();
+    window.open(guia.archivo, '_blank');
+  }
 }

--- a/frontend/plataforma-capacitacion/src/app/features/guias/services/guias.service.ts
+++ b/frontend/plataforma-capacitacion/src/app/features/guias/services/guias.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../../environments/environment';
+import { Guia } from '../../../core/models';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class GuiasService {
+  private apiUrl = `${environment.apiUrl}`;
+
+  constructor(private http: HttpClient) {}
+
+  listar(): Observable<Guia[]> {
+    return this.http.get<Guia[]>(`${this.apiUrl}/guias`);
+  }
+
+  historial(): Observable<any[]> {
+    return this.http.get<any[]>(`${this.apiUrl}/guias/vistas`);
+  }
+
+  registrarVista(guiaId: number): Observable<any> {
+    return this.http.post(`${this.apiUrl}/guias/vista`, { guia_id: guiaId });
+  }
+}


### PR DESCRIPTION
## Summary
- implement front‑end Guides feature
- add listing and history components
- create Guides service

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm test` (frontend) *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d93e3ab0c8328a7acc8945146ca6b